### PR TITLE
background.js review

### DIFF
--- a/src/chrome/js/background.js
+++ b/src/chrome/js/background.js
@@ -27,20 +27,17 @@ const taimuRipu = async () => {
 
     const setTimeoutHandler = () => 
     {
-      const videoContainer = document.getElementById("movie_player");
+      const videoContainer = document.getElementById("movie_player"); //Since the DOM can change - it is better to not cache the movie_player DOM element.
       const isAd = videoContainer?.classList.contains("ad-interrupting") || videoContainer?.classList.contains("ad-showing");
-      const skipLock = document.querySelector(".ytp-ad-preview-text")?.innerText;
-      const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
-
-      if (isAd) {
-        const videoPlayer = document.querySelector(".video-stream");
+      //Those 2 if statement with "skiplock" and "surveylock" are wrong. They are good for normal ads, but not for static ads.
+      const videoPlayer = document.querySelector(".video-stream"); // document.querySelector(".video_stream") is faster in this case, then document.getElementsByClassName("video_stream")[0]
+      if (isAd && videoPlayer) { 
         videoPlayer.muted = true; // videoPlayer.volume = 0;
         videoPlayer.currentTime = videoPlayer.duration - 0.1;
         videoPlayer.paused && videoPlayer.play()
         document.querySelector(".ytp-ad-skip-button")?.click();
         document.querySelector(".ytp-ad-skip-button-modern")?.click();
       } 
-
       resolve();
     };
 
@@ -50,24 +47,7 @@ const taimuRipu = async () => {
 
   taimuRipu();
 };
-const setTimeoutHandler = () => {
-  const videoContainer = document.getElementById("ytp-ad-overlay");
-  const isAd = videoContainer?.classList.contains("ad-interrupting") || videoContainer?.classList.contains("ad-showing");
-  const skipLock = document.querySelector(".ytp-ad-preview-text")?.innerText;
-  const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
 
-  if (isAd) {
-    const videoPlayer = document.getElementById("video-stream");
-    videoPlayer.muted = true; // videoPlayer.volume = 0;
-    videoPlayer.currentTime = videoPlayer.duration - 0.1;
-    if (videoPlayer.paused) {
-      videoPlayer.play();
-    }
-
-    const skipButtons = Array.from(document.querySelectorAll(".ytp-ad-skip-button"));
-    skipButtons.find((skipButton) => skipButton.click());
-  }
-};
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   if (

--- a/src/chrome/js/background.js
+++ b/src/chrome/js/background.js
@@ -24,26 +24,22 @@ chrome.runtime.onInstalled.addListener((details) => {
 
 const taimuRipu = async () => {
   await new Promise((resolve, _reject) => {
-    const videoContainer = document.getElementById("movie_player");
 
-    const setTimeoutHandler = () => {
+    const setTimeoutHandler = () => 
+    {
+      const videoContainer = document.getElementById("movie_player");
       const isAd = videoContainer?.classList.contains("ad-interrupting") || videoContainer?.classList.contains("ad-showing");
       const skipLock = document.querySelector(".ytp-ad-preview-text")?.innerText;
       const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
 
-      if (isAd && skipLock) {
-        const videoPlayer = document.getElementsByClassName("video-stream")[0];
+      if (isAd) {
+        const videoPlayer = document.querySelector(".video-stream");
         videoPlayer.muted = true; // videoPlayer.volume = 0;
         videoPlayer.currentTime = videoPlayer.duration - 0.1;
         videoPlayer.paused && videoPlayer.play()
-        // CLICK ON THE SKIP AD BTN
         document.querySelector(".ytp-ad-skip-button")?.click();
         document.querySelector(".ytp-ad-skip-button-modern")?.click();
-      } else if (isAd && surveyLock) {
-        // CLICK ON THE SKIP SURVEY BTN
-        document.querySelector(".ytp-ad-skip-button")?.click();
-        document.querySelector(".ytp-ad-skip-button-modern")?.click();
-      }
+      } 
 
       resolve();
     };
@@ -53,6 +49,24 @@ const taimuRipu = async () => {
   });
 
   taimuRipu();
+};
+const setTimeoutHandler = () => {
+  const videoContainer = document.getElementById("ytp-ad-overlay");
+  const isAd = videoContainer?.classList.contains("ad-interrupting") || videoContainer?.classList.contains("ad-showing");
+  const skipLock = document.querySelector(".ytp-ad-preview-text")?.innerText;
+  const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
+
+  if (isAd) {
+    const videoPlayer = document.getElementById("video-stream");
+    videoPlayer.muted = true; // videoPlayer.volume = 0;
+    videoPlayer.currentTime = videoPlayer.duration - 0.1;
+    if (videoPlayer.paused) {
+      videoPlayer.play();
+    }
+
+    const skipButtons = Array.from(document.querySelectorAll(".ytp-ad-skip-button"));
+    skipButtons.find((skipButton) => skipButton.click());
+  }
 };
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {

--- a/src/firefox/js/background.js
+++ b/src/firefox/js/background.js
@@ -26,25 +26,19 @@ const taimuRipu = async () => {
   await new Promise((resolve, _reject) => {
     const videoContainer = document.getElementById("movie_player");
 
-    const setTimeoutHandler = () => {
+    const setTimeoutHandler = () => 
+    {
+      const videoContainer = document.getElementById("movie_player"); //Since the DOM can change - it is better to not cache the movie_player DOM element.
       const isAd = videoContainer?.classList.contains("ad-interrupting") || videoContainer?.classList.contains("ad-showing");
-      const skipLock = document.querySelector(".ytp-ad-preview-text")?.innerText;
-      const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
-
-      if (isAd && skipLock) {
-        const videoPlayer = document.getElementsByClassName("video-stream")[0];
+      //Those 2 if statement with "skiplock" and "surveylock" are wrong. They are good for normal ads, but not for static ads.
+      const videoPlayer = document.querySelector(".video-stream"); // document.querySelector(".video_stream") is faster in this case, then document.getElementsByClassName("video_stream")[0]
+      if (isAd && videoPlayer) { 
         videoPlayer.muted = true; // videoPlayer.volume = 0;
         videoPlayer.currentTime = videoPlayer.duration - 0.1;
         videoPlayer.paused && videoPlayer.play()
-        // CLICK ON THE SKIP AD BTN
         document.querySelector(".ytp-ad-skip-button")?.click();
         document.querySelector(".ytp-ad-skip-button-modern")?.click();
-      } else if (isAd && surveyLock) {
-        // CLICK ON THE SKIP SURVEY BTN
-        document.querySelector(".ytp-ad-skip-button")?.click();
-        document.querySelector(".ytp-ad-skip-button-modern")?.click();
-      }
-
+      } 
       resolve();
     };
 

--- a/src/opera/js/background.js
+++ b/src/opera/js/background.js
@@ -24,27 +24,19 @@ chrome.runtime.onInstalled.addListener((details) => {
 
 const taimuRipu = async () => {
   await new Promise((resolve, _reject) => {
-    const videoContainer = document.getElementById("movie_player");
-
-    const setTimeoutHandler = () => {
+    const setTimeoutHandler = () => 
+    {
+      const videoContainer = document.getElementById("movie_player"); //Since the DOM can change - it is better to not cache the movie_player DOM element.
       const isAd = videoContainer?.classList.contains("ad-interrupting") || videoContainer?.classList.contains("ad-showing");
-      const skipLock = document.querySelector(".ytp-ad-preview-text")?.innerText;
-      const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
-
-      if (isAd && skipLock) {
-        const videoPlayer = document.getElementsByClassName("video-stream")[0];
+      //Those 2 if statement with "skiplock" and "surveylock" are wrong. They are good for normal ads, but not for static ads.
+      const videoPlayer = document.querySelector(".video-stream"); // document.querySelector(".video_stream") is faster in this case, then document.getElementsByClassName("video_stream")[0]
+      if (isAd && videoPlayer) { 
         videoPlayer.muted = true; // videoPlayer.volume = 0;
         videoPlayer.currentTime = videoPlayer.duration - 0.1;
         videoPlayer.paused && videoPlayer.play()
-        // CLICK ON THE SKIP AD BTN
         document.querySelector(".ytp-ad-skip-button")?.click();
         document.querySelector(".ytp-ad-skip-button-modern")?.click();
-      } else if (isAd && surveyLock) {
-        // CLICK ON THE SKIP SURVEY BTN
-        document.querySelector(".ytp-ad-skip-button")?.click();
-        document.querySelector(".ytp-ad-skip-button-modern")?.click();
-      }
-
+      } 
       resolve();
     };
 


### PR DESCRIPTION
I had same issue then many others. The Fadblock could'nt work right. I made a little investigation about this. I installed from this source fadblock to a Thorium: Version 117.0.5938.157 (Offizieller Build) and a Chromium Version 119.0.6045.123 (Offizieller Build) (64-Bit). Both Fadblock installed from this developer source, and I find something:

-  in the   

> fadblock/chrome/js/background.js


  ```
 const skipLock = document.querySelector(".ytp-ad-preview-text")?.innerText;
 const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;

```
variables - are undefined when a static unescapable Ad is played. The script does nothing after this happens.  When there is more ads, and the first ad so static, after the others can't be escaped too. 
I decided to make  little change in this file:
-  I deleted those two variable and conditions
-  because of the possible DOM changes in the site (youtube tantrum)- the  _**VideoContainer**_ variable  is not cached anymore.

I hope this can be a good solution for many Issues on the page. 

