### PR TITLE
[Fix]: Update Class Name for Skip Ad Button

### DIFF
--- a/src/chrome/js/background.js
+++ b/src/chrome/js/background.js
@@ -27,21 +27,25 @@ const taimuRipu = async () => {
     const videoContainer = document.getElementById("movie_player");
 
     const setTimeoutHandler = () => {
-      const isAd = videoContainer?.classList.contains("ad-interrupting") || videoContainer?.classList.contains("ad-showing");
-      const skipLock = document.querySelector(".ytp-ad-preview-text")?.innerText;
+      const isAd =
+        videoContainer?.classList.contains("ad-interrupting") ||
+        videoContainer?.classList.contains("ad-showing");
+      const skipLock = document.querySelector(
+        ".ytp-ad-preview-text-modern"
+      )?.innerText;
       const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
 
       if (isAd && skipLock) {
         const videoPlayer = document.getElementsByClassName("video-stream")[0];
         videoPlayer.muted = true; // videoPlayer.volume = 0;
         videoPlayer.currentTime = videoPlayer.duration - 0.1;
-        videoPlayer.paused && videoPlayer.play()
+        videoPlayer.paused && videoPlayer.play();
         // CLICK ON THE SKIP AD BTN
-        document.querySelector(".ytp-ad-skip-button")?.click();
+        document.querySelector(".ytp-skip-ad-button")?.click();
         document.querySelector(".ytp-ad-skip-button-modern")?.click();
       } else if (isAd && surveyLock) {
         // CLICK ON THE SKIP SURVEY BTN
-        document.querySelector(".ytp-ad-skip-button")?.click();
+        document.querySelector(".ytp-skip-ad-button")?.click();
         document.querySelector(".ytp-ad-skip-button-modern")?.click();
       }
 

--- a/src/chrome/js/background.js
+++ b/src/chrome/js/background.js
@@ -30,9 +30,9 @@ const taimuRipu = async () => {
       const isAd =
         videoContainer?.classList.contains("ad-interrupting") ||
         videoContainer?.classList.contains("ad-showing");
-      const skipLock = document.querySelector(
-        ".ytp-ad-preview-text-modern"
-      )?.innerText;
+      const skipLock =
+        document.querySelector(".ytp-ad-preview-text-modern")?.innerText ||
+        document.querySelector(".ytp-preview-ad__text")?.innerText;
       const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
 
       if (isAd && skipLock) {

--- a/src/chrome/js/content.js
+++ b/src/chrome/js/content.js
@@ -6,9 +6,9 @@ const taimuRipu = async () => {
       const isAd =
         videoContainer?.classList.contains("ad-interrupting") ||
         videoContainer?.classList.contains("ad-showing");
-      const skipLock = document.querySelector(
-        ".ytp-ad-preview-text-modern"
-      )?.innerText;
+      const skipLock =
+        document.querySelector(".ytp-ad-preview-text-modern")?.innerText ||
+        document.querySelector(".ytp-preview-ad__text")?.innerText;
       const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
 
       if (isAd && skipLock) {

--- a/src/chrome/js/content.js
+++ b/src/chrome/js/content.js
@@ -3,35 +3,48 @@ const taimuRipu = async () => {
     const videoContainer = document.getElementById("movie_player");
 
     const setTimeoutHandler = () => {
-      const isAd = videoContainer?.classList.contains("ad-interrupting") || videoContainer?.classList.contains("ad-showing");
-      const skipLock = document.querySelector(".ytp-ad-preview-text")?.innerText;
+      const isAd =
+        videoContainer?.classList.contains("ad-interrupting") ||
+        videoContainer?.classList.contains("ad-showing");
+      const skipLock = document.querySelector(
+        ".ytp-ad-preview-text-modern"
+      )?.innerText;
       const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
 
       if (isAd && skipLock) {
         const videoPlayer = document.getElementsByClassName("video-stream")[0];
         videoPlayer.muted = true; // videoPlayer.volume = 0;
         videoPlayer.currentTime = videoPlayer.duration - 0.1;
-        videoPlayer.paused && videoPlayer.play()
+        videoPlayer.paused && videoPlayer.play();
         // CLICK ON THE SKIP AD BTN
-        document.querySelector(".ytp-ad-skip-button")?.click();
+        document.querySelector(".ytp-skip-ad-button")?.click();
         document.querySelector(".ytp-ad-skip-button-modern")?.click();
       } else if (isAd && surveyLock) {
         // CLICK ON THE SKIP SURVEY BTN
-        document.querySelector(".ytp-ad-skip-button")?.click();
+        document.querySelector(".ytp-skip-ad-button")?.click();
         document.querySelector(".ytp-ad-skip-button-modern")?.click();
       }
 
-      const staticAds = [".ytd-companion-slot-renderer", ".ytd-action-companion-ad-renderer", // in-feed video ads
-                           ".ytd-watch-next-secondary-results-renderer.sparkles-light-cta", ".ytd-unlimited-offer-module-renderer", // similar components
-                           ".ytp-ad-overlay-image", ".ytp-ad-text-overlay", // deprecated overlay ads (04-06-2023)
-                           "div#root.style-scope.ytd-display-ad-renderer.yt-simple-endpoint", "div#sparkles-container.style-scope.ytd-promoted-sparkles-web-renderer",
-                           ".ytd-display-ad-renderer", ".ytd-statement-banner-renderer", ".ytd-in-feed-ad-layout-renderer", // homepage ads
-                           "div#player-ads.style-scope.ytd-watch-flexy, div#panels.style-scope.ytd-watch-flexy", // sponsors
-                           ".ytd-banner-promo-renderer", ".ytd-video-masthead-ad-v3-renderer", ".ytd-primetime-promo-renderer" // subscribe for premium & youtube tv ads
-                          ];
+      const staticAds = [
+        ".ytd-companion-slot-renderer",
+        ".ytd-action-companion-ad-renderer", // in-feed video ads
+        ".ytd-watch-next-secondary-results-renderer.sparkles-light-cta",
+        ".ytd-unlimited-offer-module-renderer", // similar components
+        ".ytp-ad-overlay-image",
+        ".ytp-ad-text-overlay", // deprecated overlay ads (04-06-2023)
+        "div#root.style-scope.ytd-display-ad-renderer.yt-simple-endpoint",
+        "div#sparkles-container.style-scope.ytd-promoted-sparkles-web-renderer",
+        ".ytd-display-ad-renderer",
+        ".ytd-statement-banner-renderer",
+        ".ytd-in-feed-ad-layout-renderer", // homepage ads
+        "div#player-ads.style-scope.ytd-watch-flexy, div#panels.style-scope.ytd-watch-flexy", // sponsors
+        ".ytd-banner-promo-renderer",
+        ".ytd-video-masthead-ad-v3-renderer",
+        ".ytd-primetime-promo-renderer", // subscribe for premium & youtube tv ads
+      ];
 
       staticAds.forEach((ad) => {
-          document.hideElementsBySelector(ad);
+        document.hideElementsBySelector(ad);
       });
 
       resolve();
@@ -44,14 +57,13 @@ const taimuRipu = async () => {
   taimuRipu();
 };
 
-
 const init = async () => {
   Document.prototype.hideElementsBySelector = (selector) =>
     [...document.querySelectorAll(selector)].forEach(
       (el) => (el.style.display = "none")
     );
 
-    taimuRipu();
+  taimuRipu();
 };
 
 init();

--- a/src/firefox/js/background.js
+++ b/src/firefox/js/background.js
@@ -27,21 +27,25 @@ const taimuRipu = async () => {
     const videoContainer = document.getElementById("movie_player");
 
     const setTimeoutHandler = () => {
-      const isAd = videoContainer?.classList.contains("ad-interrupting") || videoContainer?.classList.contains("ad-showing");
-      const skipLock = document.querySelector(".ytp-ad-preview-text")?.innerText;
+      const isAd =
+        videoContainer?.classList.contains("ad-interrupting") ||
+        videoContainer?.classList.contains("ad-showing");
+      const skipLock = document.querySelector(
+        ".ytp-ad-preview-text-modern"
+      )?.innerText;
       const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
 
       if (isAd && skipLock) {
         const videoPlayer = document.getElementsByClassName("video-stream")[0];
         videoPlayer.muted = true; // videoPlayer.volume = 0;
         videoPlayer.currentTime = videoPlayer.duration - 0.1;
-        videoPlayer.paused && videoPlayer.play()
+        videoPlayer.paused && videoPlayer.play();
         // CLICK ON THE SKIP AD BTN
-        document.querySelector(".ytp-ad-skip-button")?.click();
+        document.querySelector(".ytp-skip-ad-button")?.click();
         document.querySelector(".ytp-ad-skip-button-modern")?.click();
       } else if (isAd && surveyLock) {
         // CLICK ON THE SKIP SURVEY BTN
-        document.querySelector(".ytp-ad-skip-button")?.click();
+        document.querySelector(".ytp-skip-ad-button")?.click();
         document.querySelector(".ytp-ad-skip-button-modern")?.click();
       }
 

--- a/src/firefox/js/background.js
+++ b/src/firefox/js/background.js
@@ -30,9 +30,9 @@ const taimuRipu = async () => {
       const isAd =
         videoContainer?.classList.contains("ad-interrupting") ||
         videoContainer?.classList.contains("ad-showing");
-      const skipLock = document.querySelector(
-        ".ytp-ad-preview-text-modern"
-      )?.innerText;
+      const skipLock =
+        document.querySelector(".ytp-ad-preview-text-modern")?.innerText ||
+        document.querySelector(".ytp-preview-ad__text")?.innerText;
       const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
 
       if (isAd && skipLock) {

--- a/src/firefox/js/content.js
+++ b/src/firefox/js/content.js
@@ -6,9 +6,9 @@ const taimuRipu = async () => {
       const isAd =
         videoContainer?.classList.contains("ad-interrupting") ||
         videoContainer?.classList.contains("ad-showing");
-      const skipLock = document.querySelector(
-        ".ytp-ad-preview-text-modern"
-      )?.innerText;
+      const skipLock =
+        document.querySelector(".ytp-ad-preview-text-modern")?.innerText ||
+        document.querySelector(".ytp-preview-ad__text")?.innerText;
       const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
 
       if (isAd && skipLock) {

--- a/src/firefox/js/content.js
+++ b/src/firefox/js/content.js
@@ -3,35 +3,48 @@ const taimuRipu = async () => {
     const videoContainer = document.getElementById("movie_player");
 
     const setTimeoutHandler = () => {
-      const isAd = videoContainer?.classList.contains("ad-interrupting") || videoContainer?.classList.contains("ad-showing");
-      const skipLock = document.querySelector(".ytp-ad-preview-text")?.innerText;
+      const isAd =
+        videoContainer?.classList.contains("ad-interrupting") ||
+        videoContainer?.classList.contains("ad-showing");
+      const skipLock = document.querySelector(
+        ".ytp-ad-preview-text-modern"
+      )?.innerText;
       const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
 
       if (isAd && skipLock) {
         const videoPlayer = document.getElementsByClassName("video-stream")[0];
         videoPlayer.muted = true; // videoPlayer.volume = 0;
         videoPlayer.currentTime = videoPlayer.duration - 0.1;
-        videoPlayer.paused && videoPlayer.play()
+        videoPlayer.paused && videoPlayer.play();
         // CLICK ON THE SKIP AD BTN
-        document.querySelector(".ytp-ad-skip-button")?.click();
+        document.querySelector(".ytp-skip-ad-button")?.click();
         document.querySelector(".ytp-ad-skip-button-modern")?.click();
       } else if (isAd && surveyLock) {
         // CLICK ON THE SKIP SURVEY BTN
-        document.querySelector(".ytp-ad-skip-button")?.click();
+        document.querySelector(".ytp-skip-ad-button")?.click();
         document.querySelector(".ytp-ad-skip-button-modern")?.click();
       }
 
-      const staticAds = [".ytd-companion-slot-renderer", ".ytd-action-companion-ad-renderer", // in-feed video ads
-                           ".ytd-watch-next-secondary-results-renderer.sparkles-light-cta", ".ytd-unlimited-offer-module-renderer", // similar components
-                           ".ytp-ad-overlay-image", ".ytp-ad-text-overlay", // deprecated overlay ads (04-06-2023)
-                           "div#root.style-scope.ytd-display-ad-renderer.yt-simple-endpoint", "div#sparkles-container.style-scope.ytd-promoted-sparkles-web-renderer",
-                           ".ytd-display-ad-renderer", ".ytd-statement-banner-renderer", ".ytd-in-feed-ad-layout-renderer", // homepage ads
-                           "div#player-ads.style-scope.ytd-watch-flexy, div#panels.style-scope.ytd-watch-flexy", // sponsors
-                           ".ytd-banner-promo-renderer", ".ytd-video-masthead-ad-v3-renderer", ".ytd-primetime-promo-renderer" // subscribe for premium & youtube tv ads
-                          ];
+      const staticAds = [
+        ".ytd-companion-slot-renderer",
+        ".ytd-action-companion-ad-renderer", // in-feed video ads
+        ".ytd-watch-next-secondary-results-renderer.sparkles-light-cta",
+        ".ytd-unlimited-offer-module-renderer", // similar components
+        ".ytp-ad-overlay-image",
+        ".ytp-ad-text-overlay", // deprecated overlay ads (04-06-2023)
+        "div#root.style-scope.ytd-display-ad-renderer.yt-simple-endpoint",
+        "div#sparkles-container.style-scope.ytd-promoted-sparkles-web-renderer",
+        ".ytd-display-ad-renderer",
+        ".ytd-statement-banner-renderer",
+        ".ytd-in-feed-ad-layout-renderer", // homepage ads
+        "div#player-ads.style-scope.ytd-watch-flexy, div#panels.style-scope.ytd-watch-flexy", // sponsors
+        ".ytd-banner-promo-renderer",
+        ".ytd-video-masthead-ad-v3-renderer",
+        ".ytd-primetime-promo-renderer", // subscribe for premium & youtube tv ads
+      ];
 
       staticAds.forEach((ad) => {
-          document.hideElementsBySelector(ad);
+        document.hideElementsBySelector(ad);
       });
 
       resolve();
@@ -44,14 +57,13 @@ const taimuRipu = async () => {
   taimuRipu();
 };
 
-
 const init = async () => {
   Document.prototype.hideElementsBySelector = (selector) =>
     [...document.querySelectorAll(selector)].forEach(
       (el) => (el.style.display = "none")
     );
 
-    taimuRipu();
+  taimuRipu();
 };
 
 init();

--- a/src/opera/js/background.js
+++ b/src/opera/js/background.js
@@ -27,21 +27,25 @@ const taimuRipu = async () => {
     const videoContainer = document.getElementById("movie_player");
 
     const setTimeoutHandler = () => {
-      const isAd = videoContainer?.classList.contains("ad-interrupting") || videoContainer?.classList.contains("ad-showing");
-      const skipLock = document.querySelector(".ytp-ad-preview-text")?.innerText;
+      const isAd =
+        videoContainer?.classList.contains("ad-interrupting") ||
+        videoContainer?.classList.contains("ad-showing");
+      const skipLock = document.querySelector(
+        ".ytp-ad-preview-text-modern"
+      )?.innerText;
       const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
 
       if (isAd && skipLock) {
         const videoPlayer = document.getElementsByClassName("video-stream")[0];
         videoPlayer.muted = true; // videoPlayer.volume = 0;
         videoPlayer.currentTime = videoPlayer.duration - 0.1;
-        videoPlayer.paused && videoPlayer.play()
+        videoPlayer.paused && videoPlayer.play();
         // CLICK ON THE SKIP AD BTN
-        document.querySelector(".ytp-ad-skip-button")?.click();
+        document.querySelector(".ytp-skip-ad-button")?.click();
         document.querySelector(".ytp-ad-skip-button-modern")?.click();
       } else if (isAd && surveyLock) {
         // CLICK ON THE SKIP SURVEY BTN
-        document.querySelector(".ytp-ad-skip-button")?.click();
+        document.querySelector(".ytp-skip-ad-button")?.click();
         document.querySelector(".ytp-ad-skip-button-modern")?.click();
       }
 

--- a/src/opera/js/background.js
+++ b/src/opera/js/background.js
@@ -30,9 +30,9 @@ const taimuRipu = async () => {
       const isAd =
         videoContainer?.classList.contains("ad-interrupting") ||
         videoContainer?.classList.contains("ad-showing");
-      const skipLock = document.querySelector(
-        ".ytp-ad-preview-text-modern"
-      )?.innerText;
+      const skipLock =
+        document.querySelector(".ytp-ad-preview-text-modern")?.innerText ||
+        document.querySelector(".ytp-preview-ad__text")?.innerText;
       const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
 
       if (isAd && skipLock) {

--- a/src/opera/js/content.js
+++ b/src/opera/js/content.js
@@ -6,9 +6,9 @@ const taimuRipu = async () => {
       const isAd =
         videoContainer?.classList.contains("ad-interrupting") ||
         videoContainer?.classList.contains("ad-showing");
-      const skipLock = document.querySelector(
-        ".ytp-ad-preview-text-modern"
-      )?.innerText;
+      const skipLock =
+        document.querySelector(".ytp-ad-preview-text-modern")?.innerText ||
+        document.querySelector(".ytp-preview-ad__text")?.innerText;
       const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
 
       if (isAd && skipLock) {

--- a/src/opera/js/content.js
+++ b/src/opera/js/content.js
@@ -3,35 +3,48 @@ const taimuRipu = async () => {
     const videoContainer = document.getElementById("movie_player");
 
     const setTimeoutHandler = () => {
-      const isAd = videoContainer?.classList.contains("ad-interrupting") || videoContainer?.classList.contains("ad-showing");
-      const skipLock = document.querySelector(".ytp-ad-preview-text")?.innerText;
+      const isAd =
+        videoContainer?.classList.contains("ad-interrupting") ||
+        videoContainer?.classList.contains("ad-showing");
+      const skipLock = document.querySelector(
+        ".ytp-ad-preview-text-modern"
+      )?.innerText;
       const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
 
       if (isAd && skipLock) {
         const videoPlayer = document.getElementsByClassName("video-stream")[0];
         videoPlayer.muted = true; // videoPlayer.volume = 0;
         videoPlayer.currentTime = videoPlayer.duration - 0.1;
-        videoPlayer.paused && videoPlayer.play()
+        videoPlayer.paused && videoPlayer.play();
         // CLICK ON THE SKIP AD BTN
-        document.querySelector(".ytp-ad-skip-button")?.click();
+        document.querySelector(".ytp-skip-ad-button")?.click();
         document.querySelector(".ytp-ad-skip-button-modern")?.click();
       } else if (isAd && surveyLock) {
         // CLICK ON THE SKIP SURVEY BTN
-        document.querySelector(".ytp-ad-skip-button")?.click();
+        document.querySelector(".ytp-skip-ad-button")?.click();
         document.querySelector(".ytp-ad-skip-button-modern")?.click();
       }
 
-      const staticAds = [".ytd-companion-slot-renderer", ".ytd-action-companion-ad-renderer", // in-feed video ads
-                           ".ytd-watch-next-secondary-results-renderer.sparkles-light-cta", ".ytd-unlimited-offer-module-renderer", // similar components
-                           ".ytp-ad-overlay-image", ".ytp-ad-text-overlay", // deprecated overlay ads (04-06-2023)
-                           "div#root.style-scope.ytd-display-ad-renderer.yt-simple-endpoint", "div#sparkles-container.style-scope.ytd-promoted-sparkles-web-renderer",
-                           ".ytd-display-ad-renderer", ".ytd-statement-banner-renderer", ".ytd-in-feed-ad-layout-renderer", // homepage ads
-                           "div#player-ads.style-scope.ytd-watch-flexy, div#panels.style-scope.ytd-watch-flexy", // sponsors
-                           ".ytd-banner-promo-renderer", ".ytd-video-masthead-ad-v3-renderer", ".ytd-primetime-promo-renderer" // subscribe for premium & youtube tv ads
-                          ];
+      const staticAds = [
+        ".ytd-companion-slot-renderer",
+        ".ytd-action-companion-ad-renderer", // in-feed video ads
+        ".ytd-watch-next-secondary-results-renderer.sparkles-light-cta",
+        ".ytd-unlimited-offer-module-renderer", // similar components
+        ".ytp-ad-overlay-image",
+        ".ytp-ad-text-overlay", // deprecated overlay ads (04-06-2023)
+        "div#root.style-scope.ytd-display-ad-renderer.yt-simple-endpoint",
+        "div#sparkles-container.style-scope.ytd-promoted-sparkles-web-renderer",
+        ".ytd-display-ad-renderer",
+        ".ytd-statement-banner-renderer",
+        ".ytd-in-feed-ad-layout-renderer", // homepage ads
+        "div#player-ads.style-scope.ytd-watch-flexy, div#panels.style-scope.ytd-watch-flexy", // sponsors
+        ".ytd-banner-promo-renderer",
+        ".ytd-video-masthead-ad-v3-renderer",
+        ".ytd-primetime-promo-renderer", // subscribe for premium & youtube tv ads
+      ];
 
       staticAds.forEach((ad) => {
-          document.hideElementsBySelector(ad);
+        document.hideElementsBySelector(ad);
       });
 
       resolve();
@@ -44,14 +57,13 @@ const taimuRipu = async () => {
   taimuRipu();
 };
 
-
 const init = async () => {
   Document.prototype.hideElementsBySelector = (selector) =>
     [...document.querySelectorAll(selector)].forEach(
       (el) => (el.style.display = "none")
     );
 
-    taimuRipu();
+  taimuRipu();
 };
 
 init();

--- a/src/safari/js/fadblock.user.js
+++ b/src/safari/js/fadblock.user.js
@@ -7,59 +7,71 @@
 // Source: https://raw.githubusercontent.com/0x48piraj/fadblock/master/src/chrome/js/content.js
 
 const taimuRipu = async () => {
-    await new Promise((resolve, _reject) => {
-      const videoContainer = document.getElementById("movie_player");
-  
-      const setTimeoutHandler = () => {
-        const isAd = videoContainer?.classList.contains("ad-interrupting") || videoContainer?.classList.contains("ad-showing");
-        const skipLock = document.querySelector(".ytp-ad-preview-text")?.innerText;
-        const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
-  
-        if (isAd && skipLock) {
-          const videoPlayer = document.getElementsByClassName("video-stream")[0];
-          videoPlayer.muted = true; // videoPlayer.volume = 0;
-          videoPlayer.currentTime = videoPlayer.duration - 0.1;
-          videoPlayer.paused && videoPlayer.play()
-          // CLICK ON THE SKIP AD BTN
-          document.querySelector(".ytp-ad-skip-button")?.click();
-          document.querySelector(".ytp-ad-skip-button-modern")?.click();
-        } else if (isAd && surveyLock) {
-          // CLICK ON THE SKIP SURVEY BTN
-          document.querySelector(".ytp-ad-skip-button")?.click();
-          document.querySelector(".ytp-ad-skip-button-modern")?.click();
-        }
-  
-        const staticAds = [".ytd-companion-slot-renderer", ".ytd-action-companion-ad-renderer", // in-feed video ads
-                           ".ytd-watch-next-secondary-results-renderer.sparkles-light-cta", ".ytd-unlimited-offer-module-renderer", // similar components
-                           ".ytp-ad-overlay-image", ".ytp-ad-text-overlay", // deprecated overlay ads (04-06-2023)
-                           "div#root.style-scope.ytd-display-ad-renderer.yt-simple-endpoint", "div#sparkles-container.style-scope.ytd-promoted-sparkles-web-renderer",
-                           ".ytd-display-ad-renderer", ".ytd-statement-banner-renderer", ".ytd-in-feed-ad-layout-renderer", // homepage ads
-                           "div#player-ads.style-scope.ytd-watch-flexy, div#panels.style-scope.ytd-watch-flexy", // sponsors
-                           ".ytd-banner-promo-renderer", ".ytd-video-masthead-ad-v3-renderer", ".ytd-primetime-promo-renderer" // subscribe for premium & youtube tv ads
-                          ];
-  
-        staticAds.forEach((ad) => {
-            document.hideElementsBySelector(ad);
-        });
-  
-        resolve();
-      };
-  
-      // RUN IT ONLY AFTER 100 MILLISECONDS
-      setTimeout(setTimeoutHandler, 100);
-    });
-  
-    taimuRipu();
-  };
-  
-  
-  const init = async () => {
-    Document.prototype.hideElementsBySelector = (selector) =>
-      [...document.querySelectorAll(selector)].forEach(
-        (el) => (el.style.display = "none")
-      );
-  
-      taimuRipu();
-  };
-  
-  init();
+  await new Promise((resolve, _reject) => {
+    const videoContainer = document.getElementById("movie_player");
+
+    const setTimeoutHandler = () => {
+      const isAd =
+        videoContainer?.classList.contains("ad-interrupting") ||
+        videoContainer?.classList.contains("ad-showing");
+      const skipLock = document.querySelector(
+        ".ytp-ad-preview-text-modern"
+      )?.innerText;
+      const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
+
+      if (isAd && skipLock) {
+        const videoPlayer = document.getElementsByClassName("video-stream")[0];
+        videoPlayer.muted = true; // videoPlayer.volume = 0;
+        videoPlayer.currentTime = videoPlayer.duration - 0.1;
+        videoPlayer.paused && videoPlayer.play();
+        // CLICK ON THE SKIP AD BTN
+        document.querySelector(".ytp-skip-ad-button")?.click();
+        document.querySelector(".ytp-ad-skip-button-modern")?.click();
+      } else if (isAd && surveyLock) {
+        // CLICK ON THE SKIP SURVEY BTN
+        document.querySelector(".ytp-skip-ad-button")?.click();
+        document.querySelector(".ytp-ad-skip-button-modern")?.click();
+      }
+
+      const staticAds = [
+        ".ytd-companion-slot-renderer",
+        ".ytd-action-companion-ad-renderer", // in-feed video ads
+        ".ytd-watch-next-secondary-results-renderer.sparkles-light-cta",
+        ".ytd-unlimited-offer-module-renderer", // similar components
+        ".ytp-ad-overlay-image",
+        ".ytp-ad-text-overlay", // deprecated overlay ads (04-06-2023)
+        "div#root.style-scope.ytd-display-ad-renderer.yt-simple-endpoint",
+        "div#sparkles-container.style-scope.ytd-promoted-sparkles-web-renderer",
+        ".ytd-display-ad-renderer",
+        ".ytd-statement-banner-renderer",
+        ".ytd-in-feed-ad-layout-renderer", // homepage ads
+        "div#player-ads.style-scope.ytd-watch-flexy, div#panels.style-scope.ytd-watch-flexy", // sponsors
+        ".ytd-banner-promo-renderer",
+        ".ytd-video-masthead-ad-v3-renderer",
+        ".ytd-primetime-promo-renderer", // subscribe for premium & youtube tv ads
+      ];
+
+      staticAds.forEach((ad) => {
+        document.hideElementsBySelector(ad);
+      });
+
+      resolve();
+    };
+
+    // RUN IT ONLY AFTER 100 MILLISECONDS
+    setTimeout(setTimeoutHandler, 100);
+  });
+
+  taimuRipu();
+};
+
+const init = async () => {
+  Document.prototype.hideElementsBySelector = (selector) =>
+    [...document.querySelectorAll(selector)].forEach(
+      (el) => (el.style.display = "none")
+    );
+
+  taimuRipu();
+};
+
+init();

--- a/src/safari/js/fadblock.user.js
+++ b/src/safari/js/fadblock.user.js
@@ -14,9 +14,9 @@ const taimuRipu = async () => {
       const isAd =
         videoContainer?.classList.contains("ad-interrupting") ||
         videoContainer?.classList.contains("ad-showing");
-      const skipLock = document.querySelector(
-        ".ytp-ad-preview-text-modern"
-      )?.innerText;
+      const skipLock =
+        document.querySelector(".ytp-ad-preview-text-modern")?.innerText ||
+        document.querySelector(".ytp-preview-ad__text")?.innerText;
       const surveyLock = document.querySelector(".ytp-ad-survey")?.length > 0;
 
       if (isAd && skipLock) {


### PR DESCRIPTION
Close #178 

## Description
This PR addresses issue #178 , where changes in the class name of the skip ad button on YouTube rendered the plugin dysfunctional. The commit updates the class name to adapt to the changes made by YouTube, ensuring the seamless functioning of the plugin.

https://github.com/0x48piraj/fadblock/assets/19495220/08f39796-2f7b-4cdd-9ed7-66d6a394c048

## Related Issues
Fixes #178

## Acknowledgements
Special thanks to @gps137 for suggesting the necessary modifications.

## Reference
[Issue 178 - Comment by gps137](https://github.com/0x48piraj/fadblock/issues/178#issuecomment-2041171412)
